### PR TITLE
feat: warning for leftover wallets in mwst as profiles strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ This strategy implements migration for a PostgreSQL database that uses the `Mult
             }
 ```
 
-* `allow_missing_wallet` - [flag](#allow-missing-wallet-check) to allow wallets in database to not be migrated (bool)
+* `allow_missing_wallet` - flag to allow wallets in database to not be migrated (bool)
+    * There is a check to ensure that the wallet names passed into the migration script align with the wallet names retrieved from the database to be migrated. If a wallet name is passed in that does not correspond to an existing wallet in the database, an `UpgradeError` is raised. If a wallet name that corresponds to an existing wallet in the database is not passed into the script to be migrated, a `MissingWalletError` is raised. If the user wishes to migrate some, but not all, of the wallets in a `MultiWalletSingleTable` database, they can bypass the `MissingWalletError` by setting the `--allow-missing-wallet` argument as `True`.
 
 #### Run
 ```
@@ -148,7 +149,6 @@ This strategy implements migration for a PostgreSQL database that uses the `Mult
             }
 ```
 
-* `allow_missing_wallet` - [flag](#allow-missing-wallet-check) to allow wallets in database to not be migrated (bool)
 
 #### Run
 ```
@@ -161,10 +161,6 @@ After migration, the startup command must include the following argument:
 --multitenancy-config wallet_type=askar-profile
 ```
 
-
-#### --allow-missing-wallet check
-
-There is a check to ensure that the wallet names passed into the migration script align with the wallet names retrieved from the database to be migrated. If a wallet name is passed in that does not correspond to an existing wallet in the database, an `UpgradeError` is raised. If a wallet name that corresponds to an existing wallet in the database is not passed into the script to be migrated, a `MissingWalletError` is raised. If the user wishes to migrate some, but not all, of the wallets in a `MultiWalletSingleTable` database, they can bypass the `MissingWalletError` by setting the `--allow-missing-wallet` argument as `True`.
 
 ## Wallet location
 

--- a/acapy_wallet_upgrade/__main__.py
+++ b/acapy_wallet_upgrade/__main__.py
@@ -95,9 +95,7 @@ async def main(
         if not base_wallet_key:
             raise ValueError("Base wallet key required for mwst-as-profiles strategy")
 
-        strategy_inst = MwstAsProfilesStrategy(
-            uri, base_wallet_name, base_wallet_key, allow_missing_wallet
-        )
+        strategy_inst = MwstAsProfilesStrategy(uri, base_wallet_name, base_wallet_key)
 
     elif strategy == "mwst-as-stores":
         if parsed.scheme != "postgres":

--- a/acapy_wallet_upgrade/strategies.py
+++ b/acapy_wallet_upgrade/strategies.py
@@ -536,9 +536,7 @@ class MwstAsProfilesStrategy(Strategy):
             wallet for wallet in retrieved_wallets if wallet not in migrated_wallets
         ]
         if len(leftover_wallets) > 0:
-            LOGGER.warning(
-                f"The following wallets were not migrated: {leftover_wallets}"
-            )
+            print(f"The following wallets were not migrated: {leftover_wallets}")
 
     async def create_sub_config(self, conn: DbConnection, indy_key: dict):
         pass_key = "kdf:argon2i:13:mod?salt=" + indy_key["salt"].hex()

--- a/acapy_wallet_upgrade/strategies.py
+++ b/acapy_wallet_upgrade/strategies.py
@@ -4,6 +4,7 @@ import contextlib
 import hashlib
 import hmac
 import json
+import logging
 import os
 import re
 from typing import Dict, Optional, Union, cast
@@ -22,6 +23,7 @@ from .pg_connection import PgConnection, PgWallet
 from .pg_mwst_connection import PgMWSTConnection
 from .sqlite_connection import SqliteConnection
 
+LOGGER = logging.getLogger(__name__)
 
 # Constants
 CHACHAPOLY_KEY_LEN = 32
@@ -432,6 +434,10 @@ class Strategy(ABC):
         await wallet.insert_profile(name, enc_pk)
         return profile_key
 
+    async def retrieve_wallet_ids(self, conn):
+        wallet_id_records = await conn.fetch("""SELECT wallet_id FROM metadata""")
+        return [wallet_id[0] for wallet_id in wallet_id_records]
+
     @abstractmethod
     async def run(self):
         """Perform the upgrade."""
@@ -476,12 +482,10 @@ class MwstAsProfilesStrategy(Strategy):
         uri: str,
         base_wallet_name: str,
         base_wallet_key: str,
-        allow_missing_wallet: Optional[bool] = None,
     ):
         self.uri = uri
         self.base_wallet_name = base_wallet_name
         self.base_wallet_key = base_wallet_key
-        self.allow_missing_wallet = allow_missing_wallet
 
     async def init_profile(
         self, wallet: Wallet, name: str, base_indy_key: dict, indy_key: dict
@@ -524,6 +528,16 @@ class MwstAsProfilesStrategy(Strategy):
                 settings["wallet.name"],
                 cast(str, record.name),
                 settings["wallet.key"],
+            )
+
+    async def check_for_leftover_wallets(self, old_conn, migrated_wallets):
+        retrieved_wallets = await self.retrieve_wallet_ids(old_conn)
+        leftover_wallets = [
+            wallet for wallet in retrieved_wallets if wallet not in migrated_wallets
+        ]
+        if len(leftover_wallets) > 0:
+            LOGGER.warning(
+                f"The following wallets were not migrated: {leftover_wallets}"
             )
 
     async def create_sub_config(self, conn: DbConnection, indy_key: dict):
@@ -580,12 +594,8 @@ class MwstAsProfilesStrategy(Strategy):
                 base_conn.uri,
                 self.base_wallet_key,
             )
-
-            # TODO delete? The sub wallets may not completely cover the list of
-            # wallets in the MWST DB. Warn? Note in docs?
-            # await self.conn.check_missing_wallet_flag(
-            #     self.wallet_info, self.allow_missing_wallet
-            # )
+            # Track migrated wallets
+            migrated_wallets = [self.base_wallet_name]
 
             wallet_ids = []
             async for wallet_name, wallet_id, wallet_key in self.get_wallet_info(
@@ -596,6 +606,8 @@ class MwstAsProfilesStrategy(Strategy):
                 await self.migrate_one_profile(
                     wallet, base_indy_key, wallet_id, wallet_key
                 )
+                migrated_wallets.append(wallet_name)
+            await self.check_for_leftover_wallets(source, migrated_wallets)
 
             await sub_conn.finish_upgrade()
         finally:
@@ -631,13 +643,7 @@ class MwstAsStoresStrategy(Strategy):
         """Verify that the wallet names passed in align with
         the wallet names found in the database.
         """
-        wallet_id_list = await conn.fetch(
-            """
-            SELECT wallet_id FROM metadata
-            """
-        )
-        retrieved_wallet_keys = [wallet_id[0] for wallet_id in wallet_id_list]
-
+        retrieved_wallet_keys = await self.retrieve_wallet_ids(conn)
         for wallet_id in wallet_keys.keys():
             if wallet_id not in retrieved_wallet_keys:
                 raise UpgradeError(f"Wallet {wallet_id} not found in database")

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -153,31 +153,8 @@ async def test_migration_dbpw(postgres_with_volume):
     )
 
 
-@pytest.mark.parametrize(
-    "wallet_keys, allow_missing_wallet",
-    [
-        (
-            {
-                "agency": "agency_insecure0",
-                "alice": "alice_insecure1",
-                "bob": "bob_insecure1",
-            },
-            False,
-        ),
-        # (
-        #     {
-        #         "agency": "agency_insecure0",
-        #         "alice": "alice_insecure1",
-        #     },
-        #     True,
-        #     TODO: determine use of allow_missing_wallet flag
-        # ),
-    ],
-)
 @pytest.mark.asyncio
-async def test_migration_mwst_as_profiles(
-    postgres_with_volume, wallet_keys, allow_missing_wallet
-):
+async def test_migration_mwst_as_profiles(postgres_with_volume):
     """
     Run the migration script with the db in the docker container.
     """
@@ -188,7 +165,6 @@ async def test_migration_mwst_as_profiles(
         strategy="mwst-as-profiles",
         base_wallet_name="agency",
         base_wallet_key="agency_insecure0",
-        allow_missing_wallet=allow_missing_wallet,
     )
 
 
@@ -228,39 +204,15 @@ async def test_migration_mwst_as_separate_stores(
 
 
 @pytest.mark.parametrize(
-    "volume, strategy, wallet_keys, error",
+    "wallet_keys, error",
     [
         (
-            "mt-mwst",
-            "mwst-as-profiles",
-            {
-                "agency": "agency_insecure0",
-                "alice": "alice_insecure1",
-            },
-            MissingWalletError,
-        ),
-        (
-            "mt-mwst",
-            "mwst-as-profiles",
-            {
-                "agency": "agency_insecure0",
-                "alice": "alice_insecure1",
-                "bob": "bob_insecure1",
-                "carol": "carol_insecure1",
-            },
-            UpgradeError,
-        ),
-        (
-            "mwst",
-            "mwst-as-stores",
             {
                 "alice": "alice_insecure1",
             },
             MissingWalletError,
         ),
         (
-            "mwst",
-            "mwst-as-stores",
             {
                 "alice": "alice_insecure1",
                 "bob": "bob_insecure1",
@@ -271,18 +223,19 @@ async def test_migration_mwst_as_separate_stores(
     ],
 )
 @pytest.mark.asyncio
-async def test_migration_mwst_wallet_misalignment(
-    postgres_with_volume, volume, strategy, wallet_keys, error
+async def test_migration_mwst_as_stores_wallet_misalignment(
+    postgres_with_volume, wallet_keys, error
 ):
     """
     Run the migration script with the db in the docker container.
     """
-    port = postgres_with_volume(volume)
+    port = postgres_with_volume("mwst")
     with pytest.raises(error):
         await migrate_pg_db(
             db_port=port,
             db_name="wallets",
-            strategy=strategy,
+            strategy="mwst-as-stores",
             base_wallet_name="agency",
+            base_wallet_key="agency_insecure0",
             wallet_keys=wallet_keys,
         )


### PR DESCRIPTION
* Track wallets as they are migrated
* Post migration, check migrated wallet names against those retrieved from the metadata table
* If there are leftover wallets, log warning and the names of the wallets left behind
* Remove `allow_missing_wallet` flag from MWST as profiles strategy
* Update documentation and intermediate tests to reflect these changes

Signed-off-by: Char Howland <char@indicio.tech>