### PR TITLE
Feat/delete indy wallets flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ make sqlite
 make dbpw
 make mt-mwst
 make mwst
+make mt-mwst-leftover-wallet
 ```
 
 #### Run tests

--- a/acapy_wallet_upgrade/__main__.py
+++ b/acapy_wallet_upgrade/__main__.py
@@ -29,6 +29,7 @@ def config():
     parser.add_argument("--base-wallet-key", type=str, action="store")
     parser.add_argument("--wallet-keys", type=str, action="store")
     parser.add_argument("--allow-missing-wallet", type=str, action="store")
+    parser.add_argument("--delete-indy-wallets", type=str, action="store")
     args, _ = parser.parse_known_args(sys.argv[1:])
 
     if args.strategy not in ("dbpw", "mwst-as-profiles", "mwst-as-stores"):
@@ -67,7 +68,8 @@ async def main(
     base_wallet_name: Optional[str] = None,
     base_wallet_key: Optional[str] = None,
     wallet_keys: Optional[Dict[str, str]] = None,
-    allow_missing_wallet: Optional[bool] = None,
+    allow_missing_wallet: Optional[bool] = False,
+    delete_indy_wallets: Optional[bool] = False,
 ):
     logging.basicConfig(level=logging.WARN)
     parsed = urlparse(uri)
@@ -95,7 +97,9 @@ async def main(
         if not base_wallet_key:
             raise ValueError("Base wallet key required for mwst-as-profiles strategy")
 
-        strategy_inst = MwstAsProfilesStrategy(uri, base_wallet_name, base_wallet_key)
+        strategy_inst = MwstAsProfilesStrategy(
+            uri, base_wallet_name, base_wallet_key, delete_indy_wallets
+        )
 
     elif strategy == "mwst-as-stores":
         if parsed.scheme != "postgres":

--- a/tests/input/.gitignore
+++ b/tests/input/.gitignore
@@ -1,5 +1,6 @@
 dbpw/
 mwst/
 mt-mwst/
+mt-mwst-leftover-wallet/
 alice.db
 bob.db

--- a/tests/input/Makefile
+++ b/tests/input/Makefile
@@ -26,5 +26,11 @@ mt-mwst: | juggernaut
 	docker cp db:/var/lib/postgresql/data mt-mwst
 	docker-compose down -v
 
+mt-mwst-leftover-wallet: | juggernaut
+	docker-compose up -d carol-mwst
+	docker-compose run juggernaut-mt-mwst-leftover-wallet
+	docker cp db:/var/lib/postgresql/data mt-mwst-leftover-wallet
+	docker-compose down -v
+
 
 .PHONY: sqlite juggernaut

--- a/tests/input/Makefile
+++ b/tests/input/Makefile
@@ -1,4 +1,4 @@
-all: sqlite dbpw mwst mt-mwst
+all: sqlite dbpw mwst mt-mwst mt-mwst-leftover-wallet
 
 juggernaut:
 	docker-compose build juggernaut-sqlite

--- a/tests/input/docker-compose.yml
+++ b/tests/input/docker-compose.yml
@@ -219,6 +219,41 @@ services:
       db:
         condition: service_healthy
 
+  carol-mwst:
+    container_name: carol-mwst
+    image: docker.io/bcgovimages/aries-cloudagent:py36-1.16-1_0.7.5
+    ports:
+      - "3002:3001"
+    command: >
+      start -it http 0.0.0.0 3000
+        --label Carol
+        -ot http
+        -e http://carol-mwst:3000
+        --admin 0.0.0.0 3001 --admin-insecure-mode
+        --log-level debug
+        --genesis-url https://raw.githubusercontent.com/Indicio-tech/indicio-network/main/genesis_files/pool_transactions_testnet_genesis
+        --tails-server-base-url http://tails:6543
+        --wallet-type indy
+        --wallet-name carol
+        --wallet-key carol_insecure1
+        --wallet-storage-type postgres_storage
+        --wallet-storage-config '{"url":"db:5432","wallet_scheme":"MultiWalletSingleTable"}'
+        --wallet-storage-creds '{"account":"postgres","password":"mysecretpassword","admin_account":"postgres","admin_password":"mysecretpassword"}'
+        --preserve-exchange-records
+        --auto-provision
+        --monitor-revocation-notification
+    healthcheck:
+      test: curl -s -o /dev/null -w '%{http_code}' "http://localhost:3001/status/live" | grep "200" > /dev/null
+      start_period: 30s
+      interval: 7s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      tails:
+        condition: service_started
+      db:
+        condition: service_healthy
+
   agency-mwst:
     container_name: agency-mwst
     image: docker.io/bcgovimages/aries-cloudagent:py36-1.16-1_0.7.5
@@ -321,4 +356,17 @@ services:
     command: populate_mt_db.py
     depends_on:
       agency-mwst:
+        condition: service_healthy
+
+  juggernaut-mt-mwst-leftover-wallet:
+    build:
+      context: .
+    image: populate-indy-db
+    environment:
+      - AGENCY=http://agency-mwst:3001
+    command: populate_mt_db.py
+    depends_on:
+      agency-mwst:
+        condition: service_healthy
+      carol-mwst:
         condition: service_healthy

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -20,7 +20,8 @@ async def migrate_pg_db(
     base_wallet_name: Optional[str] = None,
     base_wallet_key: Optional[str] = None,
     wallet_keys: Optional[Dict[str, str]] = None,
-    allow_missing_wallet=None,
+    allow_missing_wallet: Optional[bool] = False,
+    delete_indy_wallets: Optional[bool] = False,
 ):
     """Run migration script on postgresql database."""
     db_host = "localhost"
@@ -43,6 +44,7 @@ async def migrate_pg_db(
         base_wallet_key,
         wallet_keys,
         allow_missing_wallet,
+        delete_indy_wallets,
     )
 
 
@@ -165,6 +167,22 @@ async def test_migration_mwst_as_profiles(postgres_with_volume):
         strategy="mwst-as-profiles",
         base_wallet_name="agency",
         base_wallet_key="agency_insecure0",
+    )
+
+
+@pytest.mark.asyncio
+async def test_migration_mwst_as_profiles_leftover_wallet_warning(postgres_with_volume):
+    """
+    Run the migration script with the db in the docker container.
+    """
+    port = postgres_with_volume("mt-mwst-leftover-wallet")
+    await migrate_pg_db(
+        db_port=port,
+        db_name="wallets",
+        strategy="mwst-as-profiles",
+        base_wallet_name="agency",
+        base_wallet_key="agency_insecure0",
+        delete_indy_wallets=True,
     )
 
 


### PR DESCRIPTION
This PR adds the option to delete the Indy wallets after migration for the `mwst-as-profiles` strategy by setting `delete_indy_wallets` as `True`. If there are "leftover" Indy wallets after migration (in the case that there are wallets in the MWST setup that were not subwallets of the base wallet and thus were not migrated), this flag will be overwritten so that those wallets are not deleted.
