### PR TITLE
feat: implement delete indy wallets option for mwst-as-stores strategy

### DIFF
--- a/acapy_wallet_upgrade/__main__.py
+++ b/acapy_wallet_upgrade/__main__.py
@@ -28,8 +28,16 @@ def config():
     parser.add_argument("--base-wallet-name", type=str, action="store")
     parser.add_argument("--base-wallet-key", type=str, action="store")
     parser.add_argument("--wallet-keys", type=str, action="store")
-    parser.add_argument("--allow-missing-wallet", type=str, action="store")
-    parser.add_argument("--delete-indy-wallets", type=str, action="store")
+    parser.add_argument("--allow-missing-wallet", action="store_true")
+    parser.add_argument("--delete-indy-wallets", action="store_true")
+    parser.add_argument(
+        "--should-confirm",
+        action="store_true",
+        help=(
+            "Indicate if user wants to be prompted for confirmation before "
+            "deleting original Indy wallets database."
+        ),
+    )
     args, _ = parser.parse_known_args(sys.argv[1:])
 
     if args.strategy not in ("dbpw", "mwst-as-profiles", "mwst-as-stores"):
@@ -70,6 +78,7 @@ async def main(
     wallet_keys: Optional[Dict[str, str]] = None,
     allow_missing_wallet: Optional[bool] = False,
     delete_indy_wallets: Optional[bool] = False,
+    should_confirm: Optional[bool] = False,
 ):
     logging.basicConfig(level=logging.WARN)
     parsed = urlparse(uri)
@@ -98,7 +107,7 @@ async def main(
             raise ValueError("Base wallet key required for mwst-as-profiles strategy")
 
         strategy_inst = MwstAsProfilesStrategy(
-            uri, base_wallet_name, base_wallet_key, delete_indy_wallets
+            uri, base_wallet_name, base_wallet_key, delete_indy_wallets, should_confirm
         )
 
     elif strategy == "mwst-as-stores":
@@ -109,7 +118,7 @@ async def main(
             raise ValueError("Wallet keys required for mwst-as-stores strategy")
 
         strategy_inst = MwstAsStoresStrategy(
-            uri, wallet_keys, allow_missing_wallet, delete_indy_wallets
+            uri, wallet_keys, allow_missing_wallet, delete_indy_wallets, should_confirm
         )
 
     else:

--- a/acapy_wallet_upgrade/__main__.py
+++ b/acapy_wallet_upgrade/__main__.py
@@ -108,7 +108,9 @@ async def main(
         if not wallet_keys:
             raise ValueError("Wallet keys required for mwst-as-stores strategy")
 
-        strategy_inst = MwstAsStoresStrategy(uri, wallet_keys, allow_missing_wallet)
+        strategy_inst = MwstAsStoresStrategy(
+            uri, wallet_keys, allow_missing_wallet, delete_indy_wallets
+        )
 
     else:
         raise UpgradeError("Invalid strategy")

--- a/acapy_wallet_upgrade/__main__.py
+++ b/acapy_wallet_upgrade/__main__.py
@@ -31,11 +31,11 @@ def config():
     parser.add_argument("--allow-missing-wallet", action="store_true")
     parser.add_argument("--delete-indy-wallets", action="store_true")
     parser.add_argument(
-        "--should-confirm",
+        "--skip-confirmation",
         action="store_true",
         help=(
-            "Indicate if user wants to be prompted for confirmation before "
-            "deleting original Indy wallets database."
+            "Indicate if user does not want to be prompted for confirmation "
+            "before deleting original Indy wallets database."
         ),
     )
     args, _ = parser.parse_known_args(sys.argv[1:])
@@ -78,7 +78,7 @@ async def main(
     wallet_keys: Optional[Dict[str, str]] = None,
     allow_missing_wallet: Optional[bool] = False,
     delete_indy_wallets: Optional[bool] = False,
-    should_confirm: Optional[bool] = False,
+    skip_confirmation: Optional[bool] = False,
 ):
     logging.basicConfig(level=logging.WARN)
     parsed = urlparse(uri)
@@ -107,7 +107,11 @@ async def main(
             raise ValueError("Base wallet key required for mwst-as-profiles strategy")
 
         strategy_inst = MwstAsProfilesStrategy(
-            uri, base_wallet_name, base_wallet_key, delete_indy_wallets, should_confirm
+            uri,
+            base_wallet_name,
+            base_wallet_key,
+            delete_indy_wallets,
+            skip_confirmation,
         )
 
     elif strategy == "mwst-as-stores":
@@ -118,7 +122,7 @@ async def main(
             raise ValueError("Wallet keys required for mwst-as-stores strategy")
 
         strategy_inst = MwstAsStoresStrategy(
-            uri, wallet_keys, allow_missing_wallet, delete_indy_wallets, should_confirm
+            uri, wallet_keys, allow_missing_wallet, delete_indy_wallets, skip_confirm
         )
 
     else:

--- a/acapy_wallet_upgrade/strategies.py
+++ b/acapy_wallet_upgrade/strategies.py
@@ -454,7 +454,9 @@ class Strategy(ABC):
 
     async def determine_wallet_deletion(self):
         if self.delete_indy_wallets:
-            if sys.stdout.isatty() and self.should_confirm:
+            if self.skip_confirmation:
+                await self.delete_wallets_database()
+            elif sys.stdout.isatty():
                 response = input(
                     "Would you like to delete the original Indy wallet database? Y/N "
                 )
@@ -463,7 +465,7 @@ class Strategy(ABC):
                 else:
                     print("Indy wallets database not deleted.")
             else:
-                await self.delete_wallets_database()
+                print("Indy wallets database not deleted.")
         else:
             print("Indy wallets database not deleted.")
 
@@ -512,13 +514,13 @@ class MwstAsProfilesStrategy(Strategy):
         base_wallet_name: str,
         base_wallet_key: str,
         delete_indy_wallets: Optional[bool] = False,
-        should_confirm: Optional[bool] = False,
+        skip_confirmation: Optional[bool] = False,
     ):
         self.uri = uri
         self.base_wallet_name = base_wallet_name
         self.base_wallet_key = base_wallet_key
         self.delete_indy_wallets = delete_indy_wallets
-        self.should_confirm = should_confirm
+        self.skip_confirmation = skip_confirmation
 
     async def init_profile(
         self, wallet: Wallet, name: str, base_indy_key: dict, indy_key: dict
@@ -667,13 +669,13 @@ class MwstAsStoresStrategy(Strategy):
         wallet_keys: Dict[str, str],
         allow_missing_wallet: Optional[bool] = False,
         delete_indy_wallets: Optional[bool] = False,
-        should_confirm: Optional[bool] = False,
+        skip_confirmation: Optional[bool] = False,
     ):
         self.uri = uri
         self.wallet_keys = wallet_keys
         self.allow_missing_wallet = allow_missing_wallet
         self.delete_indy_wallets = delete_indy_wallets
-        self.should_confirm = should_confirm
+        self.skip_confirmation = skip_confirmation
 
     def create_new_db_connection(self, wallet_name: str):
         parsed = urlparse(self.uri)

--- a/tests/intermediate/test_migration.py
+++ b/tests/intermediate/test_migration.py
@@ -221,6 +221,49 @@ async def test_migration_mwst_as_separate_stores(
     )
 
 
+@pytest.mark.asyncio
+async def test_migration_mwst_as_separate_stores_delete_indy_wallets_not_deleted(
+    postgres_with_volume,
+):
+    """
+    Run the migration script with the db in the docker container.
+    """
+    port = postgres_with_volume("mwst")
+    await migrate_pg_db(
+        db_port=port,
+        db_name="wallets",
+        strategy="mwst-as-stores",
+        wallet_keys={
+            "alice": "alice_insecure1",
+        },
+        allow_missing_wallet=True,
+        delete_indy_wallets=True,
+    )
+    # Wallets are not deleted in this scenario
+
+
+@pytest.mark.asyncio
+async def test_migration_mwst_as_separate_stores_delete_indy_wallets_deleted(
+    postgres_with_volume,
+):
+    """
+    Run the migration script with the db in the docker container.
+    """
+    port = postgres_with_volume("mwst")
+    await migrate_pg_db(
+        db_port=port,
+        db_name="wallets",
+        strategy="mwst-as-stores",
+        wallet_keys={
+            "alice": "alice_insecure1",
+            "bob": "bob_insecure1",
+        },
+        allow_missing_wallet=False,
+        delete_indy_wallets=True,
+    )
+    # Wallets are deleted in this scenario
+
+
 @pytest.mark.parametrize(
     "wallet_keys, error",
     [


### PR DESCRIPTION
This PR implements the `--delete-indy-wallets` flag for the `mwst-as-stores` strategy. If there are no missing wallets (comparing the names passed in to be migrated with those found in the database), we have the option to delete the old database. The user is prevented from allowing wallets to not be migrated and then deleting them.

* `allow_missing_wallet = False` and `delete_indy_wallets = False`: Indy wallets are not deleted
* `allow_missing_wallet = True` and `delete_indy_wallets = False`: Indy wallets are not deleted
* `allow_missing_wallet = False` and `delete_indy_wallets = True`: Indy wallets are deleted (provided the script doesn't error out if there are missing wallets)
* `allow_missing_wallet = True` and `delete_indy_wallets = True`: if there are missing wallets, the `allow_missing_wallet` flag is overwritten to `False` so that the missing wallets are not deleted. If there are no missing wallets, the Indy wallets are deleted.

These changes also include request for confirmation from the user before deleting the old database and a `--skip-confirmation` flag to allow the user to opt out of this confirmation step.